### PR TITLE
Fix undo route and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FamilyHub.V1 🏡
 
 A simple, clean, and fast web-based family finance and organization tracker.
-Built for Filipino families to track income, expenses, and daily essentials — all in one place.
+Built for Filipino families to track income, expenses, and daily essentials - all in one place.
 
 ---
 
@@ -10,12 +10,19 @@ Built for Filipino families to track income, expenses, and daily essentials — 
 - 💰 Add, edit, and delete income/expense entries
 - 📅 Auto-fill current date for entries
 - 🧾 Export financial data to CSV
-- 🌙 Dark mode toggle
 - ⚠️ Delete confirmation with safety prompt
 - 🧠 Simple JavaScript UI interactions
-- 🌍 Bilingual-ready (English + Tagalog support)
 - 🔐 Login-ready design (future-proofed)
 
 ---
 
 ## 📁 Project Structure
+
+## 🔧 Running Tests
+
+Install dependencies from `requirements.txt` and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -122,8 +122,10 @@ def delete_transaction(tid):
 
 @app.route("/undo_delete")
 def undo_delete():
-    if "user_id" not in session or "undo_tid" not in session:
+    if "user_id" not in session:
         return redirect("/login")
+    if "undo_tid" not in session:
+        return redirect("/budget")
     tid = session.pop("undo_tid", None)
     if tid:
         db.execute("UPDATE transactions SET deleted = 0 WHERE id = ?", tid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ Flask-Session
 werkzeug
 gunicorn
 bcrypt
+pytest
+pytest-flask

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_budget_requires_login(client):
+    resp = client.get('/budget')
+    assert resp.status_code == 302
+    assert '/login' in resp.headers['Location']
+
+def test_invalid_login(client):
+    resp = client.post('/login', data={'email': 'invalid@example.com', 'password': 'wrong'}, follow_redirects=True)
+    assert b'Invalid email or password.' in resp.data


### PR DESCRIPTION
## Summary
- fix README hyphen and remove unimplemented features
- redirect to budget when there is nothing to undo
- document running tests
- add pytest and pytest-flask to requirements
- create basic flask tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f80890e90832b8442912b30d2bd6a